### PR TITLE
Make wheel instead of egg

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ test:
     - hypothesis
     - zope
     - zope.interface
-    - pympler    
+    - pympler
   imports:
     - attr
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,13 +13,14 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  script: python setup.py bdist_wheel --universal;python -m wheel install --force dist/*.whl
 
 requirements:
   build:
     - python
     - setuptools
+    - wheel
   run:
     - python
 


### PR DESCRIPTION
When a conda package is marked as 'noarch: python' as attrs is, than it is better to build the conda package as a wheel instead of an egg since that package format is both architecture and python version independent.

This pull request changes the build step to build a wheel and then install using the wheel module.