### PR TITLE
Python 3.5 and 3.6 have been dropped

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,18 +13,18 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install . --no-deps --ignore-installed
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python >=3.7
     - hatchling
     - hatch-vcs
     - hatch-fancy-pypi-readme
   run:
-    - python >=3.5
+    - python >=3.7
 
 test:
   requires:


### PR DESCRIPTION
See #31 and https://conda-forge.org/docs/maintainer/updating_pkgs.html#removing-broken-packages

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
